### PR TITLE
angular-io-quickstart to 0.0.1

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -1,4 +1,7 @@
 dependencies:
+- name: angular-io-quickstart
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.1
 - name: demo210
   repository: http://jenkins-x-chartmuseum:8080
 - alias: expose


### PR DESCRIPTION
Promote angular-io-quickstart to version 0.0.1